### PR TITLE
Fixed preview on search view.

### DIFF
--- a/SearchMicro/Sources/SearchMicro/Search/SearchView.swift
+++ b/SearchMicro/Sources/SearchMicro/Search/SearchView.swift
@@ -3,9 +3,18 @@ import FeatureComponent
 import SwiftUI
 
 public struct SearchView: View {
-    @ObservedObject var viewModel = SearchViewModel()
     
-    public init() {}
+#if PREVIEW
+    let viewModel: SearchViewModel
+    
+    init(viewModel: SearchViewModel = SearchViewModel()) {
+        self.viewModel = viewModel
+    }
+    
+#else
+    @StateObject var viewModel = SearchViewModel()
+    
+#endif
     
     public var body: some View {
         VStack {
@@ -36,14 +45,13 @@ public struct SearchView: View {
                                 .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 4, trailing: 0))
                                 .id(movie.imdbId)
                                 .onTapGesture {
-                                    // TODO: Work on passing isFavorite here...
                                     viewModel.goToMovieDetails(movie: movie)
                                 }
                         }
                     }
                     .listStyle(.plain)
                     .accessibilityIdentifier("movieListView")
-                
+                    
                 case .showEmpty:
                     Text("No movies found.")
                         .subTitleTextStyle()
@@ -68,9 +76,7 @@ public struct SearchView: View {
 #Preview("State .error") {
     var viewModel = SearchViewModel()
     viewModel.state = .error
-    var view = SearchView()
-    view.viewModel = viewModel
-    
+    var view = SearchView(viewModel: viewModel)
     return view
 }
 
@@ -83,10 +89,7 @@ import DataModels
     var viewModel = SearchViewModel()
     viewModel.state = .showData
     viewModel.searchMovieResults = [movie, movie, movie, movie]
-    var view = SearchView()
-    view.viewModel = viewModel
-    
-    return view
+    return SearchView(viewModel: viewModel)
 }
 
 #endif
@@ -94,17 +97,11 @@ import DataModels
 #Preview("State .showEmpty") {
     var viewModel = SearchViewModel()
     viewModel.state = .showEmpty
-    var view = SearchView()
-    view.viewModel = viewModel
-    
-    return view
+    return SearchView(viewModel: viewModel)
 }
 
 #Preview("State .loading") {
     var viewModel = SearchViewModel()
     viewModel.state = .loading
-    var view = SearchView()
-    view.viewModel = viewModel
-    
-    return view
+    return SearchView(viewModel: viewModel)
 }

--- a/SearchMicro/Sources/SearchMicro/SearchNavigation/SearchNavigationView.swift
+++ b/SearchMicro/Sources/SearchMicro/SearchNavigation/SearchNavigationView.swift
@@ -4,11 +4,11 @@ import SwiftUI
 public struct SearchNavigationView: View {
     var viewModel = SearchNavigationViewModel()
     @ObservedObject var navPathWrapper = SearchRouter.shared.navPathWrapper
-
+    
     public init() {}
-
+    
     var didAppear: ((Self) -> Void)?
-
+    
     public var body: some View {
         NavigationStack(path: $navPathWrapper.navPath) {
             viewModel.createSearchView()
@@ -37,17 +37,14 @@ import FeatureView
 class MockSearchNavigationVieModel: SearchNavigationViewModel {
     var searchViewState: ScreenStateType = .error
     let movie = Movie(title: "Batman: The Animated Series", year: "1992–1995", imdbId: "tt0103359", type: "series", posterUrl: "https://m.media-amazon.com/images/M/MV5BOTM3MTRkZjQtYjBkMy00YWE1LTkxOTQtNDQyNGY0YjYzNzAzXkEyXkFqcGdeQXVyOTgwMzk1MTA@._V1_SX300.jpg")
-
+    
     override func createSearchView() -> SearchView {
         let viewModel = SearchViewModel()
         viewModel.state = searchViewState
         viewModel.searchMovieResults = [movie, movie, movie, movie]
-        var view = SearchView()
-        view.viewModel = viewModel
-
-        return view
+        return SearchView(viewModel: viewModel)
     }
-
+    
     override func createMovieDetailsView(movie _: Movie) -> MovieDetailsView {
         return MovieDetailsView(movie: movie)
     }
@@ -57,7 +54,7 @@ class MockSearchNavigationVieModel: SearchNavigationViewModel {
     var viewModel = MockSearchNavigationVieModel()
     var view = SearchNavigationView()
     view.viewModel = viewModel
-
+    
     return view
 }
 
@@ -66,7 +63,7 @@ class MockSearchNavigationVieModel: SearchNavigationViewModel {
     viewModel.searchViewState = .showEmpty
     var view = SearchNavigationView()
     view.viewModel = viewModel
-
+    
     return view
 }
 
@@ -75,7 +72,7 @@ class MockSearchNavigationVieModel: SearchNavigationViewModel {
     viewModel.searchViewState = .showData
     var view = SearchNavigationView()
     view.viewModel = viewModel
-
+    
     return view
 }
 
@@ -84,7 +81,7 @@ class MockSearchNavigationVieModel: SearchNavigationViewModel {
     viewModel.searchViewState = .loading
     var view = SearchNavigationView()
     view.viewModel = viewModel
-
+    
     return view
 }
 


### PR DESCRIPTION
- The SearchView should be using @StateObject, so it will retain data of search term and result after come back from navigation to detail view.
-   @ObservedObject will reinit every time when the view appear again, after navigation.
- Since the preview need data from viewModel. So the solution I found is to use If Preview, then we can create the init with view model.
- The code does not look very clean on view. But it fixed the issue.  Let me know if any one has a better idea on this.

https://github.com/AndrewBrehmAtDialexa/MovieAppMicro/assets/57606580/6a4f336a-f669-447d-a46e-8cfb4a328661

